### PR TITLE
fix autoupdate for 1.0.0+ naming

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -48,8 +48,8 @@ ram.runtime = "50M"
     arm64.sha256 = "8712d30aa7849c83c5a5c0b881808d46f589390e37d7b4555f7bd28167d5314d"
 
     autoupdate.strategy = "latest_github_release"
-    autoupdate.asset.arm64 = "fusion_.*_linux_arm64.zip"
-    autoupdate.asset.amd64 = "fusion_.*_linux_amd64.zip"
+    autoupdate.asset.arm64 = "fusion_linux_arm64.zip"
+    autoupdate.asset.amd64 = "fusion_linux_amd64.zip"
 
     [resources.system_user]
 


### PR DESCRIPTION
1.0.0 release asset naming changed